### PR TITLE
Add debug state check and test scripts for issue #27

### DIFF
--- a/debug-state.js
+++ b/debug-state.js
@@ -1,0 +1,32 @@
+// Debug state check - temporary file to investigate Issue #27
+
+// Add this to App.tsx temporarily to debug the state issue:
+
+console.log('🔍 DEBUG STATE CHECK:');
+console.log('- pins.length:', pins.length);
+console.log('- filteredPins.length:', filteredPins.length);
+console.log('- currentPackage:', currentPackage?.name);
+console.log('- isInVSCode():', isInVSCode());
+
+// Add this to export functions to see what they receive:
+// const handleExportCSV = async () => {
+//   console.log('🔍 EXPORT DEBUG:');
+//   console.log('- pins.length in export:', pins.length);
+//   console.log('- filteredPins.length in export:', filteredPins.length);
+//   
+//   if (pins.length === 0) {
+//     console.log('❌ PINS ARRAY IS EMPTY - THIS IS THE PROBLEM');
+//     return;
+//   }
+//   // ... rest of export function
+// };
+
+// Root cause analysis:
+// 1. CSV loading calls loadPackage(packageData)
+// 2. loadPackage sets state.pins = packageData.pins
+// 3. But somehow pins becomes empty in App.tsx after that
+// 4. This might be due to:
+//    - Zustand state update timing
+//    - Filter application clearing pins
+//    - State synchronization issue
+//    - Different store instances

--- a/debug-test.js
+++ b/debug-test.js
@@ -1,0 +1,52 @@
+// デバッグ用のテストスクリプト
+// ブラウザのコンソールで実行して状態を確認
+
+console.log('=== FPGA Pin Planner Debug Test ===');
+
+// 現在の状態をチェック
+const debugState = () => {
+  const store = window.__ZUSTAND_STORE__;
+  if (store) {
+    const state = store.getState();
+    console.log('📊 Current Store State:');
+    console.log('- pins.length:', state.pins?.length || 0);
+    console.log('- filteredPins.length:', state.filteredPins?.length || 0);
+    console.log('- package:', state.package?.name || 'None');
+    console.log('- selectedPins:', state.selectedPins?.size || 0);
+    
+    // 保存/エクスポート機能のチェック
+    console.log('\n🔧 Testing Export Functions:');
+    
+    // pinsとfilteredPinsの内容を詳しくチェック
+    console.log('\n📋 Pins Analysis:');
+    const pins = state.pins || [];
+    const filteredPins = state.filteredPins || [];
+    
+    console.log('pins sample (first 3):', pins.slice(0, 3).map(p => ({
+      id: p.id,
+      pinNumber: p.pinNumber,
+      signalName: p.signalName
+    })));
+    
+    console.log('filteredPins sample (first 3):', filteredPins.slice(0, 3).map(p => ({
+      id: p.id, 
+      pinNumber: p.pinNumber,
+      signalName: p.signalName
+    })));
+    
+    return {
+      pins: pins.length,
+      filteredPins: filteredPins.length,
+      package: state.package?.name,
+      hasData: pins.length > 0 || filteredPins.length > 0
+    };
+  } else {
+    console.log('❌ Zustand store not found');
+    return null;
+  }
+};
+
+// 関数をグローバルに公開
+window.debugState = debugState;
+
+console.log('✅ Debug functions loaded. Use debugState() to check current state.');

--- a/fix-issue-27-test.js
+++ b/fix-issue-27-test.js
@@ -1,0 +1,21 @@
+// Quick fix script for issue-27 test file
+const fs = require('fs');
+
+const filePath = 'src/test/issue-27-save-export.test.ts';
+let content = fs.readFileSync(filePath, 'utf8');
+
+// Replace store.getState() with store
+content = content.replace(/store\.getState\(\)/g, 'store');
+
+// Replace setState calls with direct assignment
+content = content.replace(/const currentState = store;\s*store\.setState\(\{ \.\.\.currentState, filteredPins: mockPins \}\);/g, 'store.filteredPins = mockPins;');
+content = content.replace(/const currentState = store;\s*store\.setState\(\{ \.\.\.currentState, filteredPins: \[\] \}\);/g, 'store.filteredPins = [];');
+
+// Remove state variable definitions that use store
+content = content.replace(/const state = store;\s*/g, '');
+
+// Replace state. with store. 
+content = content.replace(/state\./g, 'store.');
+
+fs.writeFileSync(filePath, content);
+console.log('Fixed issue-27 test file');


### PR DESCRIPTION
This pull request introduces several debugging and test-related scripts to help investigate and address Issue #27, which involves state synchronization problems in the application. The changes provide tools for inspecting and debugging the Zustand store state, as well as a script to patch a test file for more direct state manipulation.

Debugging tools:

* Added `debug-state.js`, which provides logging snippets to be used in `App.tsx` for tracking the state of `pins`, `filteredPins`, and related variables, and includes comments for root cause analysis of Issue #27.
* Added `debug-test.js`, a browser console script that inspects the Zustand store, prints summaries and samples of `pins` and `filteredPins`, and exposes a global `debugState` function for interactive debugging.

Test file patching:

* Added `fix-issue-27-test.js`, a Node.js script that modifies the `issue-27-save-export.test.ts` test file to replace indirect state access and updates with direct assignments, simplifying the test logic for debugging purposes.